### PR TITLE
Fix titleization handling of colons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed titleization handling of colons.
+  #3 by @mattt.
+
 ## [0.0.1] - 2021-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ import Inflection
 "Donald E. Knuth".parameterized() // "donald-e-knuth"
 "^très|Jolie-- ".parameterized() // "tres-jolie"
 
+"TheIncredibleHulk".titleized() // "The Incredible Hulk"
+"spider-man: far from home".titleized() // "Spider Man: Far From Home"
 "guardians_of_the_galaxy".titleized() // "Guardians Of The Galaxy"
 
 "HTTPRequest".underscored() // "http_request"

--- a/Sources/Inflection/Inflector.swift
+++ b/Sources/Inflection/Inflector.swift
@@ -322,7 +322,7 @@ public final class Inflector {
         }
 
         return term.split(omittingEmptySubsequences: true,
-                          whereSeparator: { !$0.isLetter && !$0.isNumber })
+                          whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != ":" })
                    .map { component in
                        let candidate = component.uppercased()
                        if acronyms.contains(candidate) {

--- a/Tests/InflectionTests/StringInflectionTests.swift
+++ b/Tests/InflectionTests/StringInflectionTests.swift
@@ -42,8 +42,9 @@ final class StringInflectionTests: XCTestCase {
     }
 
     func testTitleization() {
-        XCTAssertEqual("TheManWithoutAPast".titleized(), "The Man Without A Past")
-        XCTAssertEqual("raiders_of_the_lost_ark".titleized(), "Raiders Of The Lost Ark")
+        XCTAssertEqual("TheIncredibleHulk".titleized(), "The Incredible Hulk")
+        XCTAssertEqual("guardians_of_the_galaxy".titleized(), "Guardians Of The Galaxy")
+        XCTAssertEqual("spider-man: far from home".titleized(), "Spider Man: Far From Home")
         XCTAssertEqual("string_ending_with_id".titleized(preservingIDSuffix: true), "String Ending With Id")
     }
 


### PR DESCRIPTION
According to [the reference implementation](https://github.com/rails/rails/blob/8c590afc7c0e953810f02457c29f468383367225/activesupport/lib/active_support/inflector/methods.rb#L178), the titleization of `"x-men: the last stand"` should be `X Men: The Last Stand" (not `"X Men The Last Stand"`).